### PR TITLE
reference doc

### DIFF
--- a/lib/File/Touch.pm
+++ b/lib/File/Touch.pm
@@ -175,7 +175,9 @@ If nonzero, do not create new files. Default is zero.
 
 =item reference => $reference_file
 
-If defined, use timestamps from this file instead of current time. Default is undefined.
+If defined, use timestamps from this file instead of current time. The timestamps are read
+from the reference file when the object is created, not when C<<->touch>> is invoked.
+Default is undefined.
 
 =item time => $time
 

--- a/lib/File/Touch.pm
+++ b/lib/File/Touch.pm
@@ -224,6 +224,13 @@ If defined, use this time (in epoch seconds) instead of current time for modific
  my $count = $ref->touch(@files);
  print "$count files updated\n";
 
+=head2 Make a change to a file, keeping its timestamps unchanged
+
+ use File::Touch;
+ my $date_restorer = File::Touch->new(reference => $file);
+ # Update the contents of $file here.
+ $date_restorer->touch($file);
+
 =head1 REPOSITORY
 
 L<https://github.com/neilb/File-Touch>


### PR DESCRIPTION
It wasn't clear when the reference feature looked up the timestamps to
copy. After checking the source, document that this happens during ->new,
not ->touch. In other words, once using reference => $file, it's safe to
change or delete $file and the original timestamps will be used.

Add an example of doing this, where a file is its own reference, to
preserve its timestamps after making other changes.

The example doesn't quite match the style of the existing examples: it presupposes that `$file` has been set to something useful, and it elides making some edit to the file with a comment. I'm actually using this to set MP3 tags from filenames with `MP3::Tag`, but it seemed distracting to include that in the example, and my imagination failed to conjure up an alternative that would fit well, hence the cop-out. Obviously feel free not to include the example if you feel its skeleton nature makes it unhelpful.
