### PR TITLE
Smoke tests for File::Touch module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,7 @@ perl:
 install:
     - cpanm --notest -q Sparrow
     - sparrow plg install file-touch-smoke  
+    - "(dzil authordeps --missing | grep -vP '[^\\w:]' | xargs -n 5 -P 10 cpanm --quiet --notest)"
+    - "(dzil listdeps  --author --missing | grep -vP '[^\\w:]' | cpanm --quiet --notest)"
 
-script: "cpanm . && sparrow plg run file-touch-smoke"
+script: "export PERL5LIB=$PWD/lib && sparrow plg run file-touch-smoke"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: "perl"
+
+perl:
+  - "5.20"
+
+install:
+    - cpanm --notest -q Sparrow
+    - sparrow plg install file-touch-smoke  
+
+script: "cpanm . && sparrow plg run file-touch-smoke"


### PR DESCRIPTION
Hi Neil! This is pretty simple but hopefully useful test suite:

* check if touched filed is created ( case when file does not exist )
* check if touched file has a new access time ( atime_only mode ) and it is proper.

The test suite is sparrow plugin and gets run by  sparrow, the source code of it here - https://github.com/melezhik/file-touch-smoke 

An example of Travis job is here - https://travis-ci.org/melezhik/File-Touch/builds/180730013 

If you have any questions, pleas let me know. Probably you might see this PR as CPAN-PRC, but I am not sure if I all do right ( if I can join the PRC ? )



Regards

Alexey
 