### PR TITLE
No dereference

### DIFF
--- a/lib/File/Touch.pm
+++ b/lib/File/Touch.pm
@@ -72,19 +72,18 @@ sub new
         if ((defined $time) || (defined $atime) || (defined $mtime)) {
             croak("Incorrect usage: 'reference' should not be used with 'time', 'atime' or 'mtime' - ambiguous.");
         }
+        my $sb;
         if ($no_dereference && -l $reference) {
-            my @sb = lstat($reference) or croak("Could not lstat ($reference): $!");
-            $atime = $sb[8] unless $mtime_only;
-            $mtime = $sb[9] unless $atime_only;
+            $sb = lstat($reference) or croak("Could not lstat ($reference): $!");
         }
         elsif (-e $reference) {
-            my $sb = stat($reference) or croak("Could not stat ($reference): $!");
-            $atime = $sb->atime unless $mtime_only;
-            $mtime = $sb->mtime unless $atime_only;
+            $sb = stat($reference) or croak("Could not stat ($reference): $!");
         }
         else {
             croak("Reference file ($reference) does not exist");
         }
+        $atime = $sb->atime unless $mtime_only;
+        $mtime = $sb->mtime unless $atime_only;
     }
 
     $self->{_atime}      = $atime;

--- a/t/03-broken-symlink.t
+++ b/t/03-broken-symlink.t
@@ -10,6 +10,6 @@ use File::Touch;
 my $dir = File::Temp->newdir;
 
 symlink 'nonexistent', $dir->dirname . '/link';
-my $toucher = File::Touch->new( reference => $dir->dirname . '/link' );
-$toucher->touch( 'new' );
+my $toucher = File::Touch->new(reference => $dir->dirname . '/link', no_dereference => 1);
+$toucher->touch('new');
 ok 1;

--- a/t/03-broken-symlink.t
+++ b/t/03-broken-symlink.t
@@ -1,0 +1,15 @@
+#! perl
+
+use strict;
+use warnings;
+
+use Test::More 0.88 tests => 1;
+use File::Temp;
+use File::Touch;
+
+my $dir = File::Temp->newdir;
+
+symlink 'nonexistent', $dir->dirname . '/link';
+my $toucher = File::Touch->new( reference => $dir->dirname . '/link' );
+$toucher->touch( 'new' );
+ok 1;


### PR DESCRIPTION
In [RT#137072](https://rt.cpan.org/Public/Bug/Display.html?id=137072) I have requested `no_dereference` mode to be implemented in order to take `atime` and `mtime` values directly from the symbolic link, and not from what it points to. This PR implements this feature using `lstat` which does not dereference symbolic links. See the newly introduced test case for an example.